### PR TITLE
Change component name so it won't fail on install

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
-  "name": "AngularJS Resource",
+  "name": "angular-resource",
   "version": "1.0.4",
   "main": "./angular-resource.js",
   "dependencies": {


### PR DESCRIPTION
Running 'yeoman install angular-js' gave the error '<FATAL> Invalid
name: "AngularJS Resource" </FATAL>'; renaming "name" in component.json
to 'angular-resource' fixed the issue
