### PR TITLE
Allow call-specific headers (for example, paging).

### DIFF
--- a/angular-resource.js
+++ b/angular-resource.js
@@ -346,6 +346,14 @@ angular.module('ngResource', ['ng']).
         return ids;
       }
 
+      function extractHeaders(params, headerDefaults){
+        var ids = {};
+        forEach(headerDefaults || {}, function(value, key){
+          ids[key] = value.charAt && value.charAt(0) == '@' ? getter(params, value.substr(1)) : value;
+        });
+        return ids;
+      }
+
       function Resource(value){
         copy(value || {}, this);
       }
@@ -396,7 +404,8 @@ angular.module('ngResource', ['ng']).
           $http({
             method: action.method,
             url: route.url(extend({}, extractParams(data, action.params || {}), params)),
-            data: data
+            data: data,
+            headers: extend({}, extractHeaders(params, action.headers) || {})
           }).then(function(response) {
               var data = response.data;
 


### PR DESCRIPTION
extractHeaders and extractParams could be refactored into one function, but I developed this against v1.x-alpha and didn't want to propose code that didn't work.

``` javascript
var rsc = $resource( '...', {...}, 
{
  'get':{'method':'GET', 
    'params':{}, 
    'headers':{'Header-Key':'@MemberKey'}
  }
});
rsc.get(
  {..., 'MemberKey':"header value"}, 
  function( response ){},
  function( error ){});
```
