### PR TITLE
Add configuration for browserify to read exported module

### DIFF
--- a/angular-resource.js
+++ b/angular-resource.js
@@ -3,6 +3,10 @@
  * (c) 2010-2014 Google, Inc. http://angularjs.org
  * License: MIT
  */
+if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
+  module.exports = 'ngResource';
+}
+
 (function(window, angular, undefined) {'use strict';
 
 var $resourceMinErr = angular.$$minErr('$resource');


### PR DESCRIPTION
this configuration allows you to use the browserify require syntax(used with browserify-shim) as a DI. 
If you've shimed the file source and called it - 'angular-resource', then you can do this --
<code>
angular.module('sampleApp', [require('angular-resource')]);
